### PR TITLE
Item Updaters

### DIFF
--- a/gilded_rose.rb
+++ b/gilded_rose.rb
@@ -9,7 +9,25 @@ class GildedRose
 
   def update_quality
     @items.each do |item|
-      BasicItem.new(item).update_quality
+      item_updater(item).update_quality
     end
+  end
+
+  private
+
+  def item_updater(item)
+    updaters = {
+      'Aged Brie' => AgedBrie,
+      'Backstage passes to a TAFKAL80ETC concert' => BackstagePass,
+      'Sulfuras, Hand of Ragnaros' => Sulfuras
+    }
+
+    updater = updaters[item.name]
+    updater ||= conjured?(item.name) ? ConjuredItem : BasicItem
+    updater.new(item)
+  end
+
+  def conjured?(name)
+    name.downcase.start_with? 'conjured'
   end
 end

--- a/gilded_rose.rb
+++ b/gilded_rose.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
+Dir[File.join(File.dirname(__FILE__), 'items/*.rb')].each { |file| require file }
+
 class GildedRose
   def initialize(items)
     @items = items
   end
 
   def update_quality
-    @items.each(&:update_quality)
+    @items.each do |item|
+      BasicItem.new(item).update_quality
+    end
   end
 end

--- a/items/backstage_pass.rb
+++ b/items/backstage_pass.rb
@@ -6,9 +6,9 @@ class BackstagePass < BasicItem
   private
 
   def quality_increase
-    return -@quality if @sell_in < 1
-    return 3 if @sell_in < 6
-    return 2 if @sell_in < 11
+    return -@item.quality if @item.sell_in < 1
+    return 3 if @item.sell_in < 6
+    return 2 if @item.sell_in < 11
 
     1
   end

--- a/items/backstage_pass.rb
+++ b/items/backstage_pass.rb
@@ -6,7 +6,7 @@ class BackstagePass < BasicItem
   private
 
   def quality_increase
-    return -@quality if @sell_in.zero?
+    return -@quality if @sell_in < 1
     return 3 if @sell_in < 6
     return 2 if @sell_in < 11
 

--- a/items/basic_item.rb
+++ b/items/basic_item.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-require_relative 'item'
+class BasicItem
+  def initialize(item)
+    @item = item
+  end
 
-class BasicItem < Item
   def update_quality
-    @quality += quality_increase
-    @quality = ensure_quality_borders
-    @sell_in -= 1
+    @item.quality += quality_increase
+    @item.quality = ensure_quality_borders
+    @item.sell_in -= 1
   end
 
   private
@@ -24,11 +26,11 @@ class BasicItem < Item
   end
 
   def ensure_quality_borders
-    quality = [@quality, min_quality].max
+    quality = [@item.quality, min_quality].max
     [quality, max_quality].min
   end
 
   def quality_increase
-    @sell_in.positive? ? quality_change : quality_change * 2
+    @item.sell_in.positive? ? quality_change : quality_change * 2
   end
 end

--- a/items/sulfuras.rb
+++ b/items/sulfuras.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative 'item'
+require_relative 'basic_item'
 
-class Sulfuras < Item
+class Sulfuras < BasicItem
   def update_quality; end
 end

--- a/spec/gilded_rose_spec.rb
+++ b/spec/gilded_rose_spec.rb
@@ -7,21 +7,21 @@ describe GildedRose do
   describe '#update_quality' do
     let(:items) do
       [
-        BasicItem.new('dagger', 10, 20),
-        ConjuredItem.new('conjured dagger', 10, 20),
-        AgedBrie.new('Aged Brie (from cave)', -10, 50),
-        Sulfuras.new('Sulfuras, Hand of Someone', 0, 80),
-        BackstagePass.new('Backstage pass', 4, 25)
+        Item.new('dagger', 10, 20),
+        Item.new('conjured dagger', 10, 20),
+        Item.new('Aged Brie (from cave)', -10, 50),
+        Item.new('Sulfuras, Hand of Someone', 0, 80),
+        Item.new('Backstage pass', 4, 25)
       ]
     end
 
     let(:expected_items) do
       [
-        BasicItem.new('dagger', 9, 19),
-        ConjuredItem.new('conjured dagger', 9, 18),
-        AgedBrie.new('Aged Brie (from cave)', -11, 50),
-        Sulfuras.new('Sulfuras, Hand of Someone', 0, 80),
-        BackstagePass.new('Backstage pass', 3, 28)
+        Item.new('dagger', 9, 19),
+        Item.new('conjured dagger', 9, 18),
+        Item.new('Aged Brie (from cave)', -11, 50),
+        Item.new('Sulfuras, Hand of Someone', 0, 80),
+        Item.new('Backstage pass', 3, 28)
       ]
     end
     subject! { described_class.new(items).update_quality }

--- a/spec/gilded_rose_spec.rb
+++ b/spec/gilded_rose_spec.rb
@@ -5,7 +5,7 @@ Dir[File.join(File.dirname(__FILE__), '../items/*.rb')].each { |file| require fi
 
 describe GildedRose do
   describe '#update_quality' do
-    let(:items) do
+    items =
       [
         Item.new('dagger', 10, 20),
         Item.new('conjured dagger', 10, 20),
@@ -13,9 +13,8 @@ describe GildedRose do
         Item.new('Sulfuras, Hand of Someone', 0, 80),
         Item.new('Backstage pass', 4, 25)
       ]
-    end
 
-    let(:expected_items) do
+    expected_items =
       [
         Item.new('dagger', 9, 19),
         Item.new('conjured dagger', 9, 18),
@@ -23,13 +22,18 @@ describe GildedRose do
         Item.new('Sulfuras, Hand of Someone', 0, 80),
         Item.new('Backstage pass', 3, 28)
       ]
-    end
     subject! { described_class.new(items).update_quality }
 
-    it 'does not crash' do
-      items.zip(expected_items).each do |actual, expected|
+    items.zip(expected_items).each do |actual, expected|
+      it 'doesnt change item name' do
         expect(actual.name).to eq(expected.name)
+      end
+
+      it 'updates sell_in correctly' do
         expect(actual.sell_in).to eq(expected.sell_in)
+      end
+
+      it 'updates quality correctly' do
         expect(actual.quality).to eq(expected.quality)
       end
     end

--- a/spec/gilded_rose_spec.rb
+++ b/spec/gilded_rose_spec.rb
@@ -1,41 +1,70 @@
 # frozen_string_literal: true
 
 require File.join(File.dirname(__FILE__), '..', 'gilded_rose')
-Dir[File.join(File.dirname(__FILE__), '../items/*.rb')].each { |file| require file }
+require_relative '../items/item'
 
 describe GildedRose do
   describe '#update_quality' do
-    items =
+    let(:items) do
       [
         Item.new('dagger', 10, 20),
         Item.new('conjured dagger', 10, 20),
-        Item.new('Aged Brie (from cave)', -10, 50),
-        Item.new('Sulfuras, Hand of Someone', 0, 80),
-        Item.new('Backstage pass', 4, 25)
+        Item.new('Aged Brie', -10, 50),
+        Item.new('Sulfuras, Hand of Ragnaros', 0, 80),
+        Item.new('Backstage passes to a TAFKAL80ETC concert', 4, 25)
       ]
+    end
 
-    expected_items =
+    let(:expected_items) do
       [
         Item.new('dagger', 9, 19),
         Item.new('conjured dagger', 9, 18),
-        Item.new('Aged Brie (from cave)', -11, 50),
-        Item.new('Sulfuras, Hand of Someone', 0, 80),
-        Item.new('Backstage pass', 3, 28)
+        Item.new('Aged Brie', -11, 50),
+        Item.new('Sulfuras, Hand of Ragnaros', 0, 80),
+        Item.new('Backstage passes to a TAFKAL80ETC concert', 3, 28)
       ]
+    end
     subject! { described_class.new(items).update_quality }
 
-    items.zip(expected_items).each do |actual, expected|
-      it 'doesnt change item name' do
+    let(:actual) { items[index] }
+    let(:expected) { expected_items[index] }
+
+    shared_examples 'updates item' do
+      it 'updates item' do
         expect(actual.name).to eq(expected.name)
-      end
-
-      it 'updates sell_in correctly' do
         expect(actual.sell_in).to eq(expected.sell_in)
-      end
-
-      it 'updates quality correctly' do
         expect(actual.quality).to eq(expected.quality)
       end
+    end
+
+    context 'when basic item' do
+      let(:index) { 0 }
+
+      include_examples 'updates item'
+    end
+
+    context 'when conjured item' do
+      let(:index) { 1 }
+
+      include_examples 'updates item'
+    end
+
+    context 'when aged brie' do
+      let(:index) { 2 }
+
+      include_examples 'updates item'
+    end
+
+    context 'when sulfuras' do
+      let(:index) { 3 }
+
+      include_examples 'updates item'
+    end
+
+    context 'when backstage pass' do
+      let(:index) { 4 }
+
+      include_examples 'updates item'
     end
   end
 end

--- a/spec/items/backstage_pass_spec.rb
+++ b/spec/items/backstage_pass_spec.rb
@@ -35,13 +35,20 @@ describe BackstagePass do
       it_behaves_like 'an item with increasing quality'
     end
 
-    context 'when after concert' do
+    context 'when just after concert' do
       let(:sell_in) { 0 }
       let(:quality) { 42 }
       let(:expected_quality_change) { -42 }
 
       it_behaves_like 'an item'
       it_behaves_like 'an item with decreasing quality'
+    end
+
+    context 'when 1 day after concert' do
+      let(:sell_in) { -1 }
+      let(:expected_quality_change) { 0 }
+
+      it_behaves_like 'an item'
     end
   end
 end

--- a/spec/items/shared_context.rb
+++ b/spec/items/shared_context.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require_relative '../../items/item'
+
 shared_context 'item context' do
   let(:sell_in) { 10 }
   let(:quality) { 20 }
   let(:sell_in_change) { -1 }
   let(:min_quality) { 0 }
   let(:max_quality) { 50 }
-  let(:item) { described_class.new(name, sell_in, quality) }
-  subject! { item.update_quality }
+  let(:item) { Item.new(name, sell_in, quality) }
+  subject! { described_class.new(item).update_quality }
 end

--- a/texttest_fixture.rb
+++ b/texttest_fixture.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/ruby -w
+
+require File.join(File.dirname(__FILE__), 'gilded_rose')
+require_relative 'items/item'
+
+puts "OMGHAI!"
+items = [
+  Item.new(name="+5 Dexterity Vest", sell_in=10, quality=20),
+  Item.new(name="Aged Brie", sell_in=2, quality=0),
+  Item.new(name="Elixir of the Mongoose", sell_in=5, quality=7),
+  Item.new(name="Sulfuras, Hand of Ragnaros", sell_in=0, quality=80),
+  Item.new(name="Sulfuras, Hand of Ragnaros", sell_in=-1, quality=80),
+  Item.new(name="Backstage passes to a TAFKAL80ETC concert", sell_in=15, quality=20),
+  Item.new(name="Backstage passes to a TAFKAL80ETC concert", sell_in=10, quality=49),
+  Item.new(name="Backstage passes to a TAFKAL80ETC concert", sell_in=5, quality=49),
+  # This Conjured item does not work properly yet
+  Item.new(name="Conjured Mana Cake", sell_in=3, quality=6), # <-- :O
+]
+
+days = 2
+if ARGV.size > 0
+  days = ARGV[0].to_i + 1
+end
+
+gilded_rose = GildedRose.new items
+(0...days).each do |day|
+  puts "-------- day #{day} --------"
+  puts "name, sellIn, quality"
+  items.each do |item|
+    puts item
+  end
+  puts ""
+  gilded_rose.update_quality
+end


### PR DESCRIPTION
1) Fixed `BackstagePass` negative sell_in case.
2) New Item classes (`BasicItem`, `AgedBrie`, ...) now act like Item updaters.
3) `GildedRose#update_quality` maps each Item to corresponding updater class.
